### PR TITLE
Character encoding is jacked on GAE #4

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -159,7 +159,20 @@ So it looks like we can just create our own GAE install in Travis-CI, for some r
 thinking we didn't need to do this, anyway, I think this file will be helpful to get things
 working: https://github.com/GoogleCloudPlatform/continuous-deployment-demo/blob/master/.travis.yml
 After looking at the GAE Travis example I'm going to try installing the `java` component in
-Travis. So this post
+Travis.
+I'm giving up on Travis CI, moving on to CircleCI. So I'm giving up on tihs today, for some
+reason CircleCI and Travis are making this difficult, interesting so see how each service handles
+ the Google authentication keys. Travis using their own encryption tool and CircleCI using a
+ base64 encoded string and an environment variable.
+
+Jacked encoding, Issue #4
+First good hit tonight on the "black diamond with a question mark" in my text:
+http://stackoverflow.com/questions/5462693/java-removing-strange-characters-from-a-stringz
+The solution is using the java.text.Normalizer class to remove the bad characters, turns out other
+sites do this too, I just didnt' realize. This works great on my mac but sadly I need to use the
+Normalizer to get this working cross-platform. I blame Numbers for jacking this up.
+
+
 
 Links:
 * https://github.com/HPI-Information-Systems/Metanome/wiki/Installing-the-google-styleguide-settings-in-intellij-and-eclipse

--- a/src/main/java/com/cmcllc/parse/CalendarEventUtil.java
+++ b/src/main/java/com/cmcllc/parse/CalendarEventUtil.java
@@ -9,10 +9,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.text.Normalizer;
 import java.util.Optional;
 
 import static com.cmcllc.util.DateTimeUtils.toiCalDate;
 import static com.cmcllc.util.DateTimeUtils.toiCalDateTimeOptional;
+import static java.text.Normalizer.normalize;
 
 /**
  * Created by chrismaki on 12/5/16.
@@ -54,10 +56,13 @@ public class CalendarEventUtil {
       vEvent.getProperties().add(new Uid(event.getUuid().toString()));
 
       if (StringUtils.isNotBlank(event.getDescription())) {
-        vEvent.getProperties().add(new Description(event.getDescription()));
+        // FIX: https://github.com/macInfinity/calendar-monster/issues/4
+        String normalizedDescription = normalize(event.getDescription(), Normalizer.Form.NFC);
+        vEvent.getProperties().add(new Description(normalizedDescription));
       }
       if (StringUtils.isNotBlank(event.getLocation())) {
-        vEvent.getProperties().add(new Location(event.getLocation()));
+        String normalizedLocation = normalize(event.getLocation(), Normalizer.Form.NFC);
+        vEvent.getProperties().add(new Location(normalizedLocation));
       }
       // only mark private if set as private
       if (event.isPrivateEvent()) {
@@ -72,7 +77,8 @@ public class CalendarEventUtil {
             event.getAlarmMinutes(), 0).negate();
         VAlarm alarm = new VAlarm(duratoin);
         alarm.getProperties().add(Action.DISPLAY);
-        alarm.getProperties().add(new Description(event.getAlarmDescription()));
+        String normalizedAlarmDesc = normalize(event.getAlarmDescription(), Normalizer.Form.NFC);
+        alarm.getProperties().add(new Description(normalizedAlarmDesc));
         vEvent.getAlarms().add(alarm);
 
       }


### PR DESCRIPTION
Found out that Numbers is converting the apostrophe character (\u0027) into the right single quotation mark (\u2019), this resulted in black diamonds with a question mark in the text. Finally got it working thanks to the Normalizer class.